### PR TITLE
add property policy for rabbitmq 3.4.3 cluster

### DIFF
--- a/src/RabbitMQ/Management/Entity/Exchange.php
+++ b/src/RabbitMQ/Management/Entity/Exchange.php
@@ -16,9 +16,10 @@ class Exchange extends AbstractEntity
     public $internal = false;
     public $arguments = array();
     public $message_stats = array();
+    public $policy;
 
     protected function getJsonParameters()
     {
-        return array('type', 'auto_delete', 'durable', 'internal', 'arguments', 'vhost', 'name');
+        return array('type', 'auto_delete', 'durable', 'internal', 'arguments', 'vhost', 'name', 'policy');
     }
 }

--- a/src/RabbitMQ/Management/Entity/Queue.php
+++ b/src/RabbitMQ/Management/Entity/Queue.php
@@ -30,6 +30,7 @@ class Queue extends AbstractEntity
     public $idle_since;
     public $incoming = array();
     public $deliveries = array();
+    public $synchronised_slave_nodes = array();
 
     public function getBindings()
     {


### PR DESCRIPTION
Issue:
When calling APIClient->listExchanges(), Entity RabbitMQ\Management\Entity\Exchange does not have property policy

Rabbitmq version : 3.4.3 cluster with two nodes using policy ha_all
