### PR TITLE
added patches to work with RabbitMQ 3.6.1

### DIFF
--- a/src/RabbitMQ/Management/Entity/Exchange.php
+++ b/src/RabbitMQ/Management/Entity/Exchange.php
@@ -16,9 +16,10 @@ class Exchange extends AbstractEntity
     public $internal = false;
     public $arguments = array();
     public $message_stats = array();
+    public $policy;
 
     protected function getJsonParameters()
     {
-        return array('type', 'auto_delete', 'durable', 'internal', 'arguments', 'vhost', 'name');
+        return array('type', 'auto_delete', 'durable', 'internal', 'arguments', 'vhost', 'name', 'policy');
     }
 }

--- a/src/RabbitMQ/Management/Entity/Queue.php
+++ b/src/RabbitMQ/Management/Entity/Queue.php
@@ -42,10 +42,12 @@ class Queue extends AbstractEntity
     public $message_bytes_unacknowledged;
     public $message_bytes_ram;
     public $message_bytes_persistent;
-    public $synchronised_slave_nodes;
-    public $recoverable_slaves;
+    public $synchronised_slave_nodes = array();
+    public $recoverable_slaves = array();
+    public $head_message_timestamp;
     public $disk_reads;
     public $disk_writes;
+    public $exclusive;
 
     public function getBindings()
     {


### PR DESCRIPTION
Updated to work with RabbitMQ Server 3.6.1, includes some from other open PRs.

Currently overriding alchemy's composer.json with this until a merge:

```
  "repositories": [
    {
      "type": "composer",
      "url": "https://wpackagist.org"
    },
    {
      "type": "vcs",
      "url" : "https://github.com/bzberlin/RabbitMQ-Management-API-Client"
    }
  ],

  "require": {
    "alchemy/rabbitmq-management-client": "dev-master",
  },

```
